### PR TITLE
Update SiD_o2_v01.xml

### DIFF
--- a/SiD/compact/SiD_o2_v01/SiD_o2_v01.xml
+++ b/SiD/compact/SiD_o2_v01/SiD_o2_v01.xml
@@ -56,7 +56,7 @@
     <constant name="SiTracker_BarrelLayers" value="SiTracker_EndcapLayers + 1"/>
 
     <constant name="ECalBarrel_half_length" value="1765.0*mm" />
-    <constant name="ECalBarrel_rmin" value="1265.0*mm" />
+    <constant name="ECalBarrel_rmin" value="1264.0*mm" />
     <constant name="ECalBarrel_rmax" value="1403.0*mm" />
     <constant name="ECalBarrel_symmetry" value="12" />
    


### PR DESCRIPTION
Update to be used in conjunction with ECalBarrel driver update. Changed "ECalBarrel_rmin=1264" from 1265 so that barrel fits in the allotted space. Note that this value disagrees with the engineering design, but extends into empty space in front of the ECal (see discussion on https://silicondetector.slack.com/messages/detector_geometry/ )

This change would need to be applied to SiD_o2_v02 as well